### PR TITLE
Fix failing CI pipeline

### DIFF
--- a/.github/workflows/test_esp_app.yml
+++ b/.github/workflows/test_esp_app.yml
@@ -8,7 +8,7 @@ jobs:
     name: Run Test App on target
     runs-on: [self-hosted, linux, docker, "${{ matrix.espidf_target }}"]  # (expects tags with the same name as espidf_target)
     container:
-      image: python:3.7-buster
+      image: python:3.9-bullseye
       options: --privileged  # (privileged mode has access to serial ports)
     strategy:
       fail-fast: false
@@ -24,7 +24,9 @@ jobs:
           path: test_app/build
       - name: Install Python packages for PyTest
         env:
-          PIP_EXTRA_INDEX_URL: "https://dl.espressif.com/pypi"
+          PIP_PREFER_BINARY: true
+          PIP_INDEX_URL: "https://dl.espressif.com/pypi/"
+          PIP_EXTRA_INDEX_URL: "https://pypi.org/simple"
         run: |
           pip install \
             pytest-embedded \


### PR DESCRIPTION
This PR addresses the CI pipeline failure caused by the inability to find a compatible Python wheel for the `cryptography` package on `dl.espressif.com/pypi`. The `cryptography` package is a dependency of `pytest-embedded-serial-esp` through `esptool`.

The `esptool` package specifies its cryptography dependency as `cryptography>=2.1.4`. Whenever a new version of `cryptography` is released, `pip` attempts to fetch the latest version. This becomes problematic for ARM architecture (Raspberry PI) as there are no pre-built wheels available on pypi.org.

We do host a compatible wheel on our private registry (https://dl.espressif.com/pypi/), but pip defaults to looking for the exact version and Python version on the standard registry (pypi.org/simple). If it doesn't find a compatible wheel, it attempts to compile from source, which fails due to the absence of the Rust toolchain.

This PR sets our private registry (dl.espressif.com) as the default package index for pip. This ensures that pip will fetch the cryptography wheel from our registry, even if it's not the latest version, as long as it satisfies the `>=2.1.4` condition.

***

**Example** - this is pulling a wheel `40.0.1` (latest is `41.0.3`), because it prefers binary package from our pypi registry:
- https://github.com/espressif/gh-esp-test-template/actions/runs/6232327592/job/16915398726?pr=3#step:5:28